### PR TITLE
fix off center issue with floating items

### DIFF
--- a/imports/blocks/nav/nav-css.js
+++ b/imports/blocks/nav/nav-css.js
@@ -23,7 +23,7 @@ export default StyleSheet.create({
       position: "fixed",
       maxWidth: "80px",
       top: 0,
-      paddingLeft: "5px",
+      // paddingLeft: "5px",
       // border for light nav
       // borderRight: "1px solid #ddd",
 

--- a/stylesheets/_hacks.scss
+++ b/stylesheets/_hacks.scss
@@ -106,3 +106,8 @@ blockquote p {
 .plain {
   text-decoration: none;
 }
+
+
+.floating:before {
+  margin-right: 0!important; // XXX JAMES SAID THIS IS OKAY
+}


### PR DESCRIPTION
The negative margin in junction is added to account for whitespace. Since react introduces no whitespace, we don't need it!

This should be looked at in a number of places but so far everything looks 💯 