### PR TITLE
fix fake removal of all payments

### DIFF
--- a/imports/pages/profile/settings/Payments/index.js
+++ b/imports/pages/profile/settings/Payments/index.js
@@ -10,6 +10,7 @@ import Layout from "./Layout";
 // XXX remove cache: false once we feel good about caching
 const mapQueriesToProps = () => ({
   data: {
+    forceFetch: true,
     query: gql`
       query PaymentDetails {
         accounts: savedPayments(cache: false) {


### PR DESCRIPTION
Fix what appeared to be removal of all payments when removing one (it didn't actually do that)

Closes #1040, #1045 and #861 