### PR TITLE
Fix stories loading issue

### DIFF
--- a/imports/pages/stories/stories.Single.js
+++ b/imports/pages/stories/stories.Single.js
@@ -46,14 +46,15 @@ const GET_STORY_QUERY = gql`
   }
 `;
 
-const withStory = graphql(GET_STORY_QUERY, { name: "story" }, {
+const withStory = graphql(GET_STORY_QUERY, {
+  name: "story",
   options: ownProps => ({
     variables: { id: ownProps.params.id },
   }),
 });
 
-@withStory
 @connect()
+@withStory
 @ReactMixin.decorate(Likeable)
 @ReactMixin.decorate(Shareable)
 @ReactMixin.decorate(Headerable)
@@ -75,6 +76,7 @@ export default class StoriesSingle extends Component {
 
   render() {
     const { content } = this.props.story;
+    console.log(content);
 
     if (!content) {
       // loading

--- a/imports/pages/stories/stories.Single.js
+++ b/imports/pages/stories/stories.Single.js
@@ -76,7 +76,6 @@ export default class StoriesSingle extends Component {
 
   render() {
     const { content } = this.props.story;
-    console.log(content);
 
     if (!content) {
       // loading


### PR DESCRIPTION
the graphql() call's second parameter object was closed too early, causing 3 args to that call.