### PR TITLE
Changed invalid data prop to live

### DIFF
--- a/imports/components/live/index.js
+++ b/imports/components/live/index.js
@@ -66,7 +66,7 @@ export default class Live extends Component {
   }
 
   handleLiveChange = (nextProps) => {
-    const { live } = nextProps.data;
+    const { live } = nextProps.live;
     if (!live) return;
 
     const isLive = live.live;


### PR DESCRIPTION
I'm not 100% sure this ever worked. (I think) this only runs when we're NOT live and go live and vise versa. I've never watched that happen live.