### PR TITLE
Fixed conditionals on toggle

### DIFF
--- a/imports/components/controls/toggle.js
+++ b/imports/components/controls/toggle.js
@@ -14,13 +14,13 @@ export default class Toggle extends Component {
   }
 
   componentWillMount() {
-    if (this.props.state !== null || this.props.state !== undefined) {
+    if (this.props.state !== null && this.props.state !== undefined) {
       this.setState({ active: this.props.state });
     }
   }
 
   componentWillReceiveProps(nextProps) {
-    if (nextProps.state !== null || this.props.state !== undefined) {
+    if (nextProps.state !== null && this.props.state !== undefined) {
       this.setState({ active: nextProps.state });
     }
   }


### PR DESCRIPTION
Don't want the state being set if EITHER condition is true, so moved from || to &&.

I assume this used to work before linting, where we changed from != to !==