### PR TITLE
Fix Repeat One

### DIFF
--- a/imports/components/players/audio/audio.PlayerUtility.js
+++ b/imports/components/players/audio/audio.PlayerUtility.js
@@ -175,7 +175,8 @@ export default class AudioPlayerUtility extends Component {
   }
 
   next = () => {
-    this.player.release();
+    // XXX Warning: leaving this out may break
+    // this.player.release();
 
     const { playing, order, repeat } = this.props.audio;
     const playlist = this.tracksWithFiles();
@@ -225,7 +226,7 @@ export default class AudioPlayerUtility extends Component {
   }
 
   previous = () => {
-    this.player.release();
+    // this.player.release();
 
     const { playing, order, repeat } = this.props.audio;
     const playlist = this.tracksWithFiles();


### PR DESCRIPTION
Removed `this.player.release()` in next and prev methods, leaving it in createPlayer.

This will definitely need to be checked in beta, but skipping quickly does not cause crashes with this.