### PR TITLE
Redirect Query Param

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -9,7 +9,6 @@
     "babel-root-slash-import",
     "transform-react-router-optimize",
     "transform-inline-environment-variables",
-    "transform-react-constant-elements",
     "transform-decorators-legacy",
     "react-require",
     "react-remove-prop-types",

--- a/imports/blocks/accounts/__tests__/index.js
+++ b/imports/blocks/accounts/__tests__/index.js
@@ -1,0 +1,117 @@
+import { Meteor } from "meteor/meteor";
+import { shallow } from "enzyme";
+
+import { AccountsContainer } from "../index";
+
+describe("redirect after sign in", () => {
+  beforeEach(() => {
+    // make window.location.href writable
+    Object.defineProperty(window.location, "href", {
+      writable: true,
+      value: "/"
+    });
+    // mock Meteor.user
+    Meteor.user = jest.fn();
+  });
+
+  it("redirects to relative url", () => {
+    const url = "/test";
+    const accountsMock = mockAccountsStore();
+    const locationMock = mockLocationStore(url);
+    const hideMock = jest.fn();
+
+    const wrapper = shallow(
+      <AccountsContainer
+        accounts={accountsMock}
+        location={locationMock}
+        hide={hideMock}
+      />
+    );
+
+    wrapper.setProps({
+      accounts: {
+        ...accountsMock,
+        authorized: true,
+      },
+    });
+
+    expect(window.location.href).toBe(url);
+  });
+
+  it("redirects to external url", () => {
+    const url = "http://test.com";
+    const accountsMock = mockAccountsStore();
+    const locationMock = mockLocationStore(url);
+    const hideMock = jest.fn();
+
+    const wrapper = shallow(
+      <AccountsContainer
+        accounts={accountsMock}
+        location={locationMock}
+        hide={hideMock}
+      />
+    );
+
+    wrapper.setProps({
+      accounts: {
+        ...accountsMock,
+        authorized: true,
+      },
+    });
+
+    expect(window.location.href).toBe(url);
+  });
+
+  it("does not redirect if no query param", () => {
+    const accountsMock = mockAccountsStore();
+    const locationMock = {
+      query: {},
+    };
+    const hideMock = jest.fn();
+
+    const wrapper = shallow(
+      <AccountsContainer
+        accounts={accountsMock}
+        location={locationMock}
+        hide={hideMock}
+      />
+    );
+
+    wrapper.setProps({
+      accounts: {
+        ...accountsMock,
+        authorized: true,
+      },
+    });
+
+    expect(window.location.href).toBe("/");
+  });
+});
+
+const mockAccountsStore = (overrides) => {
+  const defaults = {
+    data: {},
+    errors: {},
+    success: false,
+    forgot: false,
+    authorized: false,
+    person: {},
+    showWelcome: false,
+    alternateAccounts: {},
+    peopleWithoutAccountEmails: {},
+    resettingAccount: false,
+  };
+
+  return {
+    ...defaults,
+    ...overrides,
+  };
+};
+
+const mockLocationStore = (redirect) => (
+  {
+    query: {
+      redirect
+    },
+  }
+);

--- a/imports/blocks/accounts/index.js
+++ b/imports/blocks/accounts/index.js
@@ -54,6 +54,7 @@ class AccountsContainer extends Component { // eslint-disable-line
     save: PropTypes.func,
     clear: PropTypes.func,
     submit: PropTypes.func,
+    location: PropTypes.object,
   }
 
   state = {
@@ -83,6 +84,12 @@ class AccountsContainer extends Component { // eslint-disable-line
         this.setState({ loading: false });
         // follow up action
         if (this.props.onFinished) return this.props.onFinished();
+
+        // redirect after signin or register
+        const { redirect } = this.props.location.query;
+        if (redirect) {
+          window.location.href = redirect;
+        }
 
         // close the modal
         this.props.hide();
@@ -280,6 +287,5 @@ export default withPerson(
 );
 
 export {
-  Accounts,
   AccountsContainer,
 };

--- a/imports/blocks/accounts/index.js
+++ b/imports/blocks/accounts/index.js
@@ -15,35 +15,7 @@ import Success from "./Success";
 import ForgotPassword from "./ForgotPassword";
 import SuccessCreate from "./SuccessCreate";
 
-const mapDispatchToProps = { ...accountsActions, ...modalActions };
-
-const PERSON_QUERY = gql`
-  query GetPersonByGuid($guid:ID) {
-    person(guid:$guid) {
-      firstName
-      lastName
-      email
-      photo
-      id: entityId
-      personId: entityId
-    }
-  }
-`;
-
-const withPerson = graphql(PERSON_QUERY, {
-  options: (ownProps) => ({
-    ssr: false,
-    variables: {
-      guid: (
-        ownProps.location && ownProps.location.query && ownProps.location.query.guid
-      ),
-    },
-  }),
-});
-
-@connect((state) => ({ location: state.routing.location }), mapDispatchToProps)
-@withPerson
-export default class AccountsWithData extends Component {
+class Accounts extends Component {
 
   static propTypes = {
     setAccount: PropTypes.func.isRequired,
@@ -60,12 +32,10 @@ export default class AccountsWithData extends Component {
   }
 
   render() {
-    return <AccountsContainer {...this.props} />;
+    return <AccountsContainerWithData {...this.props} />;
   }
 }
 
-// We only care about the accounts state
-@connect((state) => ({ accounts: state.accounts }), mapDispatchToProps)
 class AccountsContainer extends Component { // eslint-disable-line
 
   static propTypes = {
@@ -270,3 +240,46 @@ class AccountsContainer extends Component { // eslint-disable-line
     );
   }
 }
+
+const mapDispatchToProps = { ...accountsActions, ...modalActions };
+
+const PERSON_QUERY = gql`
+  query GetPersonByGuid($guid:ID) {
+    person(guid:$guid) {
+      firstName
+      lastName
+      email
+      photo
+      id: entityId
+      personId: entityId
+    }
+  }
+`;
+
+const withPerson = graphql(PERSON_QUERY, {
+  options: (ownProps) => ({
+    ssr: false,
+    variables: {
+      guid: (
+        ownProps.location && ownProps.location.query && ownProps.location.query.guid
+      ),
+    },
+  }),
+});
+
+const AccountsContainerWithData = connect((state) => ({
+  accounts: state.accounts,
+}), mapDispatchToProps
+)(AccountsContainer);
+
+export default withPerson(
+  connect((state) => ({
+    location: state.routing.location,
+  }), mapDispatchToProps
+  )(Accounts)
+);
+
+export {
+  Accounts,
+  AccountsContainer,
+};


### PR DESCRIPTION
Using external (`?redirect=http://test.com`) or internal (`?redirect=/groups/finder`) urls, you can redirect the user after they sign in or create an account.

Should work on all instances of the Accounts/OnBoarding component.