### PR TITLE
Added enzyme-to-json for snapshot testing

### DIFF
--- a/imports/components/forms/__tests__/Input.js
+++ b/imports/components/forms/__tests__/Input.js
@@ -4,6 +4,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 import Input from '../Input.js';
 import { getSingleSpecWrapper } from "../../../util/tests/data-spec.js";
+import { mountToJson } from "enzyme-to-json";
 
 const generateComponent = (additionalProps={}) => (
     <Input {...additionalProps} />
@@ -29,7 +30,7 @@ it('Name input does not allow <> in field', () => {
 
 it ("should render with no props", () => {
   let component = mount(generateComponent());
-  expect(component.html()).toMatchSnapshot();
+  expect(mountToJson(component)).toMatchSnapshot();
 });
 
 // XXX should input ID be the label? Can contain spaces

--- a/imports/components/forms/__tests__/__snapshots__/Input.js.snap
+++ b/imports/components/forms/__tests__/__snapshots__/Input.js.snap
@@ -1,1 +1,20 @@
-exports[`test should render with no props 1`] = `"<div class=\"input\" data-spec=\"input-wrapper\"><label></label><input maxlength=\"\" data-spec=\"input\"></div>"`;
+exports[`test should render with no props 1`] = `
+<Input>
+  <div
+    className="input"
+    data-spec="input-wrapper"
+    style={Object {}}>
+    <Label>
+      <label
+        style={Object {}} />
+    </Label>
+    <input
+      data-spec="input"
+      maxLength=""
+      onBlur={[Function anonymous]}
+      onChange={[Function anonymous]}
+      onFocus={[Function anonymous]}
+      style={Object {}} />
+  </div>
+</Input>
+`;

--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "babel-traverse": "^6.11.4",
     "css-loader": "^0.25.0",
     "enzyme": "^2.5.1",
+    "enzyme-to-json": "^1.3.0",
     "es6-promise": "^3.2.1",
     "eslint": "^3.6.0",
     "eslint-config-airbnb": "11.1.0",


### PR DESCRIPTION
This will make it possible to `mount()`, `shallow()`, or `render()` with enzyme, and then print the component in a json style format for Jest snapshots. 

The repo: https://github.com/adriantoine/enzyme-to-json?utm_content=buffer6b78b&utm_medium=social&utm_source=twitter.com&utm_campaign=buffer

